### PR TITLE
Close keyboard when user changes page on Intro Screen

### DIFF
--- a/lib/pages/intro_screen.dart
+++ b/lib/pages/intro_screen.dart
@@ -203,6 +203,7 @@ class _IntroScreenWidgetsState extends State<IntroScreenWidgets> {
         onChange: (int _) {
           FocusScopeNode currentFocus = FocusScope.of(context);
           if (!currentFocus.hasPrimaryFocus) {
+            // unfocusing dismisses the keyboard
             currentFocus.unfocus();
           }
         },


### PR DESCRIPTION
This is a small change for convenience, it looks a bit janky when the keyboard remains.

Test it out to see if it works on iOS: press on text box, then swipe to the next page with the keyboard open. It should close automatically.