### PR TITLE
Don't allow backups (and other things)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -9,9 +9,12 @@
     <!-- For pedometer -->
     <uses-permission android:name="android.gms.permission.ACTIVITY_RECOGNITION"/>
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
-        android:label="nudge_me"
-        android:icon="@mipmap/ic_launcher">
+        android:label="NudgeMe"
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"


### PR DESCRIPTION
Backing up the app means SharedPreferences/database/etc is saved, which may break the app when installing new updates (that depend on a fresh start).