### PR TITLE
Lazy load contact avatar after initial retrieval

### DIFF
--- a/lib/pages/contact_share_page.dart
+++ b/lib/pages/contact_share_page.dart
@@ -47,6 +47,17 @@ class _ContactSharePageState extends State<ContactSharePage> {
         )
       : CircleAvatar(child: Text(c.initials()));
 
+  void _updateAvatars() async {
+    _contacts.forEach((contact) async {
+        final avatar = await ContactsService.getAvatar(contact, photoHighRes: false);
+        if (avatar != null) {
+          setState(() {
+              contact.avatar = avatar;
+          });
+        }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final fab = FloatingActionButton(
@@ -60,13 +71,14 @@ class _ContactSharePageState extends State<ContactSharePage> {
 
     return Scaffold(
       body: FutureBuilder(
-          future: ContactsService.getContacts(),
+          future: ContactsService.getContacts(withThumbnails: false),
           builder: (context, futureData) {
             if (futureData.hasData) {
               List<Contact> contacts = futureData.data.toList(growable: false);
               if (_contacts == null || contacts.length != _contacts.length) {
                 // contacts must have updated
                 _contacts = contacts;
+                _updateAvatars();
                 _selected = List<bool>.generate(
                     contacts.length, (index) => false,
                     growable: false);


### PR DESCRIPTION
Closes #136.

This speeds up displaying the page and is noticeable if you have lots of contacts.