### PR TITLE
Hide testing page if in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,20 @@
 
 [![Flutter Checks](https://github.com/UCLComputerScience/COMP0016_2020_21_Team26/actions/workflows/flutter.yml/badge.svg)](https://github.com/UCLComputerScience/COMP0016_2020_21_Team26/actions/workflows/flutter.yml)
 
-V2 of the CarerCare app.
+NudgeMe is V2 of the CarerCare app.
 
 This is built on Flutter's stable branch.
+
+## Deployment
+
+### Android
+
+1. Install flutter, and use `flutter doctor` to check if it's set up correctly.
+2. Run `flutter build apk -t lib/main_production.dart` in the project directory.
+This builds the production version, meant for end users. It does not display the
+dev screen or send remote error reports. For the version used during development,
+simply run `flutter build apk`.
+3. Install the apk on an Android device.
 
 ## Tests
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,9 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:uni_links/uni_links.dart';
 import 'main_pages.dart';
 
+/// true if app is in production, meant for end users
+bool isProduction = false;
+
 /// key to retrieve [bool] that is true if setup is done
 const FIRST_TIME_DONE_KEY = "first_time_done";
 
@@ -34,7 +37,7 @@ final _sentry = SentryClient(SentryOptions(
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  _appInit();
+  appInit();
 
   // captures platform/native errors
   FlutterError.onError = (FlutterErrorDetails details) {
@@ -85,8 +88,8 @@ Future<bool> _isFirstTime() async {
       !prefs.getBool(FIRST_TIME_DONE_KEY);
 }
 
-void _appInit() async {
-  await initUniLinks();
+void appInit() async {
+  await _initUniLinks();
   initNotification();
 
   if (await _isFirstTime()) {
@@ -97,7 +100,7 @@ void _appInit() async {
 /// The deeplink that opened this app if any. Could be null.
 Uri initialUri;
 
-Future<Null> initUniLinks() async {
+Future<Null> _initUniLinks() async {
   try {
     // in case platform fails
     initialUri = await getInitialUri();

--- a/lib/main_pages.dart
+++ b/lib/main_pages.dart
@@ -26,27 +26,37 @@ const BASE_URL = "https://comp0016.cyberchris.xyz";
 enum NavBarIndex { wellbeing, home, network, settings, testing }
 
 class MainPages extends StatefulWidget {
-  // NOTE: SHOULD change [NavBarIndex] if changing this order
-  final navBarItems = [
-    TabItem(
-        icon: Icon(Icons.bar_chart, color: Colors.white), title: "Wellbeing"),
-    TabItem(icon: Icon(Icons.home, color: Colors.white), title: "Home"),
-    TabItem(icon: Icon(Icons.people, color: Colors.white), title: "Network"),
-    TabItem(icon: Icon(Icons.settings, color: Colors.white), title: "Settings"),
-    TabItem(icon: Icon(Icons.receipt, color: Colors.white), title: "Testing"),
-  ];
-
   @override
   State<StatefulWidget> createState() => _MainPagesState();
 }
 
 class _MainPagesState extends State<MainPages> {
+  List<TabItem> navBarItems;
+
   int _selectedIndex = NavBarIndex.home.index;
   StreamSubscription _linksSub;
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey();
 
   /// number of unread wellbeing data
   int _unreadNum;
+
+  /// returns the navigation bar items, depending on whether in production.
+  /// NOTE: SHOULD change [NavBarIndex] if changing the order of navBarItems.
+  List<TabItem> _getNavBarItems() {
+    List<TabItem> items = [
+      TabItem(
+          icon: Icon(Icons.bar_chart, color: Colors.white), title: "Wellbeing"),
+      TabItem(icon: Icon(Icons.home, color: Colors.white), title: "Home"),
+      TabItem(icon: Icon(Icons.people, color: Colors.white), title: "Network"),
+      TabItem(
+          icon: Icon(Icons.settings, color: Colors.white), title: "Settings"),
+    ];
+    if (!isProduction) {
+      items.add(TabItem(
+          icon: Icon(Icons.receipt, color: Colors.white), title: "Testing"));
+    }
+    return items;
+  }
 
   @override
   void initState() {
@@ -68,6 +78,8 @@ class _MainPagesState extends State<MainPages> {
       // warn user, maybe create a snackbar?
       print(err);
     });
+
+    navBarItems = _getNavBarItems();
   }
 
   void _handleAddFriendDeeplink(Uri uri) {
@@ -113,7 +125,7 @@ class _MainPagesState extends State<MainPages> {
       body: SafeArea(child: pages[_selectedIndex]),
       bottomNavigationBar: ConvexAppBar.badge(badgeMap,
           style: TabStyle.react,
-          items: widget.navBarItems,
+          items: navBarItems,
           initialActiveIndex: _selectedIndex,
           onTap: _onItemTapped,
           top: -16, // affects size of curve,

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/cupertino.dart';
+import 'package:nudge_me/main.dart';
+
+void main() {
+  isProduction = true;
+
+  WidgetsFlutterBinding.ensureInitialized();
+  appInit();
+
+  runApp(MyApp());
+}

--- a/lib/pages/checkup.dart
+++ b/lib/pages/checkup.dart
@@ -74,7 +74,8 @@ class _WellbeingCheckWidgetsState extends State<WellbeingCheckWidgets> {
   void _checkWellbeing(final int n) async {
     assert(n >= 1);
     final List<WellbeingItem> items =
-        await Provider.of<UserWellbeingDB>(context, listen: false).getLastNWeeks(n + 1);
+        await Provider.of<UserWellbeingDB>(context, listen: false)
+            .getLastNWeeks(n + 1);
     if (items.length == n + 1 &&
         _isDecreasing(items.map((item) => item.wellbeingScore).toList())) {
       // if there were enough scores, and they were decreasing

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.4.2+0
+version: 1.4.3+0
 
 environment:
   sdk: ">=2.10.0 <3.0.0"


### PR DESCRIPTION
Adds an alternative main function, such that you can specify `-t lib/main_production.dart` option to build for production.
Works for both building and running with flutter (on command line).

![Screenshot_20210306-224845.jpg](https://user-images.githubusercontent.com/46009390/110222946-27bd1d00-7ece-11eb-96a7-581d75622c66.jpg)