### PR TITLE
Ios app name, remove unused libraries from pubspec.yaml 

### DIFF
--- a/ios/Runner/Info-Release.plist
+++ b/ios/Runner/Info-Release.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>nudge_me</string>
+	<string>NudgeMe</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -789,13 +789,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
-  splashscreen:
-    dependency: "direct main"
-    description:
-      name: splashscreen
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.5"
   sqflite:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   share: ^0.6.5+4
   settings_ui: ^0.6.0
   contacts_service: ^0.4.6
-  splashscreen: ^1.3.5
   flutter_sms: ^2.1.1
 
   # data-related
@@ -55,7 +54,6 @@ dependencies:
 
   # UI
   charts_flutter: ^0.9.0
-  #introduction_screen: ^1.0.9
   introduction_screen: #forked the intro screen package to add a scrollbar
     git:
       url: https://github.com/saachipahwa/introduction_screen.git


### PR DESCRIPTION
Just realised the app name on ios appeared as  nudge_me so changed it to NudgeMe, also removed splashscreen lib and intro screen comment